### PR TITLE
redirect sign in page to dashboard after signed in

### DIFF
--- a/apps/frontend/src/app/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/frontend/src/app/auth/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,7 @@
 import SignInViewPage from "@/features/auth/components/sign-in-view";
+import { auth } from "@clerk/nextjs/server";
 import { Metadata } from "next";
+import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: "Authentication | Sign In",
@@ -7,5 +9,11 @@ export const metadata: Metadata = {
 };
 
 export default async function Page() {
+  const { userId } = await auth();
+
+  if (userId) {
+    redirect("/dashboard");
+  }
+
   return <SignInViewPage />;
 }


### PR DESCRIPTION
unless user type dashboard path directly there is no way user to get in. 
So if user already signed in then we redirect sign in page to dashboard